### PR TITLE
Integrate SyncAsync Bridge with Client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@ pubsub
 .cursor
 .project
 .claude
-
+CLAUDE.md
 # OS files
 .DS_Store
 Thumbs.db

--- a/messaging/publisher.go
+++ b/messaging/publisher.go
@@ -221,6 +221,15 @@ func (p *MessagePublisher) PublishCommand(ctx context.Context, cmd contracts.Com
 	return p.Publish(ctx, cmd, append(defaultOpts, options...)...)
 }
 
+// PublishQuery publishes a query message
+func (p *MessagePublisher) PublishQuery(ctx context.Context, query contracts.Query, options ...PublishOption) error {
+	defaultOpts := []PublishOption{
+		WithExchange("mmate.queries"),
+		WithRoutingKey(fmt.Sprintf("qry.%s", query.GetType())),
+	}
+	return p.Publish(ctx, query, append(defaultOpts, options...)...)
+}
+
 // PublishEvent publishes an event message
 func (p *MessagePublisher) PublishEvent(ctx context.Context, evt contracts.Event, options ...PublishOption) error {
 	defaultOpts := []PublishOption{


### PR DESCRIPTION
- Add bridge field to Client struct for lazy initialization
- Add Bridge() method to Client for request-response patterns
- Add missing PublishQuery method to MessagePublisher
- Update Client.Close() to properly cleanup bridge resources
- Enable synchronous request-response over async messaging