### PR TITLE
Implement enterprise features for mmate-go

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ Teams using Mmate-Go ship messaging features 10x faster with built-in reliabilit
 ## 🛣️ **Messaging Framework Roadmap**
 
 ### ✅ **Current (v1.0)**
-- RabbitMQ message broker transport integration
+- RabbitMQ and amazonMQ message broker transport integration
 - Enterprise message queue reliability features
 - Message workflow orchestration  
 - Service-scoped message monitoring

--- a/interceptors/ttl_retry_interceptor.go
+++ b/interceptors/ttl_retry_interceptor.go
@@ -1,0 +1,138 @@
+package interceptors
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/glimte/mmate-go/contracts"
+	"github.com/glimte/mmate-go/internal/reliability"
+)
+
+// TTLRetryInterceptor implements retry logic using TTL-based scheduling
+type TTLRetryInterceptor struct {
+	scheduler   *reliability.TTLRetryScheduler
+	retryPolicy reliability.RetryPolicy
+	queueName   string
+	logger      *slog.Logger
+}
+
+// TTLRetryInterceptorOptions configures the TTL retry interceptor
+type TTLRetryInterceptorOptions struct {
+	RetryPolicy reliability.RetryPolicy
+	QueueName   string
+	Logger      *slog.Logger
+}
+
+// NewTTLRetryInterceptor creates a new TTL-based retry interceptor
+func NewTTLRetryInterceptor(scheduler *reliability.TTLRetryScheduler, opts *TTLRetryInterceptorOptions) *TTLRetryInterceptor {
+	if opts == nil {
+		opts = &TTLRetryInterceptorOptions{}
+	}
+
+	if opts.Logger == nil {
+		opts.Logger = slog.Default()
+	}
+
+	if opts.RetryPolicy == nil {
+		opts.RetryPolicy = reliability.NewExponentialBackoff(
+			100*time.Millisecond,
+			30*time.Second,
+			2.0,
+			5,
+		)
+	}
+
+	return &TTLRetryInterceptor{
+		scheduler:   scheduler,
+		retryPolicy: opts.RetryPolicy,
+		queueName:   opts.QueueName,
+		logger:      opts.Logger,
+	}
+}
+
+// Intercept implements the Interceptor interface
+func (r *TTLRetryInterceptor) Intercept(ctx context.Context, msg contracts.Message, next MessageHandler) error {
+	// Try to get retry information from message headers/metadata
+	retryAttempt := r.getRetryAttempt(ctx, msg)
+	
+	r.logger.Debug("Processing message with TTL retry",
+		"messageId", msg.GetID(),
+		"attempt", retryAttempt)
+
+	// Execute the handler
+	err := next.Handle(ctx, msg)
+	if err == nil {
+		return nil
+	}
+
+	// Check if this is a scheduled retry error (message already scheduled)
+	var scheduledErr *reliability.ScheduledRetryError
+	if errors.As(err, &scheduledErr) {
+		r.logger.Info("Message already scheduled for retry",
+			"messageId", msg.GetID(),
+			"attempt", scheduledErr.AttemptNumber,
+			"retryAt", scheduledErr.RetryAt)
+		return nil // Don't propagate error since retry is handled
+	}
+
+	// Check if we should retry
+	shouldRetry, delay := r.retryPolicy.ShouldRetry(retryAttempt, err)
+	if !shouldRetry {
+		r.logger.Error("Message failed and won't be retried",
+			"messageId", msg.GetID(),
+			"attempt", retryAttempt,
+			"error", err)
+		return err
+	}
+
+	// Schedule retry using TTL
+	retryErr := r.scheduler.ScheduleRetry(ctx, msg, r.queueName, retryAttempt, r.retryPolicy, delay, err)
+	if retryErr != nil {
+		r.logger.Error("Failed to schedule TTL retry",
+			"messageId", msg.GetID(),
+			"error", retryErr)
+		return err // Return original error
+	}
+
+	r.logger.Info("Message scheduled for TTL retry",
+		"messageId", msg.GetID(),
+		"attempt", retryAttempt+1,
+		"delay", delay)
+
+	// Return nil to indicate message was handled (retry scheduled)
+	return nil
+}
+
+// Name returns the interceptor name
+func (r *TTLRetryInterceptor) Name() string {
+	return "TTLRetryInterceptor"
+}
+
+// getRetryAttempt extracts retry attempt number from context or message
+func (r *TTLRetryInterceptor) getRetryAttempt(ctx context.Context, msg contracts.Message) int {
+	// Try to get from interceptor context first
+	if intercCtx, ok := GetInterceptorContext(ctx); ok {
+		if attempt, exists := intercCtx.Get("retry-attempt"); exists {
+			if attemptInt, ok := attempt.(int); ok {
+				return attemptInt
+			}
+		}
+	}
+
+	// Default to 0 for new messages
+	return 0
+}
+
+// WithQueueName sets the queue name for this interceptor
+func (r *TTLRetryInterceptor) WithQueueName(queueName string) *TTLRetryInterceptor {
+	r.queueName = queueName
+	return r
+}
+
+// WithLogger sets the logger for this interceptor
+func (r *TTLRetryInterceptor) WithLogger(logger *slog.Logger) *TTLRetryInterceptor {
+	r.logger = logger
+	return r
+}

--- a/internal/journal/sync_mutation_journal.go
+++ b/internal/journal/sync_mutation_journal.go
@@ -1,0 +1,425 @@
+package journal
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// EntityMutationType represents entity-level mutations for sync
+type EntityMutationType string
+
+const (
+	EntityCreate EntityMutationType = "entity.create"
+	EntityUpdate EntityMutationType = "entity.update"
+	EntityDelete EntityMutationType = "entity.delete"
+	EntityPatch  EntityMutationType = "entity.patch"
+	EntityMerge  EntityMutationType = "entity.merge"
+)
+
+// SyncStatus represents the synchronization status of a mutation
+type SyncStatus string
+
+const (
+	SyncStatusPending   SyncStatus = "pending"
+	SyncStatusSynced    SyncStatus = "synced"
+	SyncStatusFailed    SyncStatus = "failed"
+	SyncStatusConflict  SyncStatus = "conflict"
+	SyncStatusIgnored   SyncStatus = "ignored"
+)
+
+// EntityMutationRecord represents an entity-level mutation for synchronization
+type EntityMutationRecord struct {
+	ID             string                 `json:"id"`
+	ServiceID      string                 `json:"serviceId"`
+	EntityType     string                 `json:"entityType"`
+	EntityID       string                 `json:"entityId"`
+	EntityVersion  int64                  `json:"entityVersion"`
+	MutationType   EntityMutationType     `json:"mutationType"`
+	Timestamp      time.Time              `json:"timestamp"`
+	CorrelationID  string                 `json:"correlationId"`
+	CausationID    string                 `json:"causationId,omitempty"`
+	Payload        json.RawMessage        `json:"payload"`
+	BeforeState    json.RawMessage        `json:"beforeState,omitempty"`
+	AfterState     json.RawMessage        `json:"afterState,omitempty"`
+	SyncStatus     SyncStatus             `json:"syncStatus"`
+	SyncedAt       *time.Time             `json:"syncedAt,omitempty"`
+	SyncError      string                 `json:"syncError,omitempty"`
+	ConflictsWith  []string               `json:"conflictsWith,omitempty"`
+	Metadata       map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// MutationQuery represents a query for mutations
+type MutationQuery struct {
+	EntityType    string     `json:"entityType,omitempty"`
+	EntityID      string     `json:"entityId,omitempty"`
+	ServiceID     string     `json:"serviceId,omitempty"`
+	CorrelationID string     `json:"correlationId,omitempty"`
+	SyncStatus    SyncStatus `json:"syncStatus,omitempty"`
+	FromTime      *time.Time `json:"fromTime,omitempty"`
+	ToTime        *time.Time `json:"toTime,omitempty"`
+	Limit         int        `json:"limit,omitempty"`
+	Offset        int        `json:"offset,omitempty"`
+}
+
+// SyncMutationJournal extends the basic mutation journal with sync capabilities
+type SyncMutationJournal interface {
+	MutationJournal
+
+	// RecordEntityMutation records an entity-level mutation
+	RecordEntityMutation(ctx context.Context, record *EntityMutationRecord) error
+
+	// GetEntityMutations retrieves mutations for a specific entity
+	GetEntityMutations(ctx context.Context, entityType, entityID string) ([]*EntityMutationRecord, error)
+
+	// GetCorrelatedMutations retrieves mutations with the same correlation ID
+	GetCorrelatedMutations(ctx context.Context, correlationID string) ([]*EntityMutationRecord, error)
+
+	// GetUnsyncedMutations retrieves mutations that haven't been synced
+	GetUnsyncedMutations(ctx context.Context, limit int) ([]*EntityMutationRecord, error)
+
+	// MarkAsSynced marks mutations as successfully synced
+	MarkAsSynced(ctx context.Context, mutationIDs []string, syncedAt time.Time) error
+
+	// MarkAsFailed marks mutations as sync failed
+	MarkAsFailed(ctx context.Context, mutationIDs []string, syncError string) error
+
+	// QueryMutations retrieves mutations based on query criteria
+	QueryMutations(ctx context.Context, query *MutationQuery) ([]*EntityMutationRecord, error)
+
+	// GetConflicts retrieves mutations that have sync conflicts
+	GetConflicts(ctx context.Context) ([]*EntityMutationRecord, error)
+
+	// ResolveConflict resolves a sync conflict
+	ResolveConflict(ctx context.Context, mutationID string, resolution SyncStatus) error
+}
+
+// InMemorySyncMutationJournal provides an in-memory implementation with sync capabilities
+type InMemorySyncMutationJournal struct {
+	*InMemoryJournal
+	entityMutations  []*EntityMutationRecord
+	byEntityID       map[string][]*EntityMutationRecord
+	byCorrelationID  map[string][]*EntityMutationRecord
+	bySyncStatus     map[SyncStatus][]*EntityMutationRecord
+	syncMu           sync.RWMutex
+	serviceID        string
+}
+
+// SyncJournalOption configures the sync mutation journal
+type SyncJournalOption func(*InMemorySyncMutationJournal)
+
+// WithServiceID sets the service ID for the journal
+func WithServiceID(serviceID string) SyncJournalOption {
+	return func(j *InMemorySyncMutationJournal) {
+		j.serviceID = serviceID
+	}
+}
+
+// NewInMemorySyncMutationJournal creates a new in-memory sync mutation journal
+func NewInMemorySyncMutationJournal(baseOpts []InMemoryJournalOption, syncOpts ...SyncJournalOption) *InMemorySyncMutationJournal {
+	baseJournal := NewInMemoryJournal(baseOpts...)
+	
+	j := &InMemorySyncMutationJournal{
+		InMemoryJournal:  baseJournal,
+		entityMutations:  make([]*EntityMutationRecord, 0),
+		byEntityID:       make(map[string][]*EntityMutationRecord),
+		byCorrelationID:  make(map[string][]*EntityMutationRecord),
+		bySyncStatus:     make(map[SyncStatus][]*EntityMutationRecord),
+		serviceID:        "unknown-service",
+	}
+
+	for _, opt := range syncOpts {
+		opt(j)
+	}
+
+	return j
+}
+
+// RecordEntityMutation records an entity-level mutation
+func (j *InMemorySyncMutationJournal) RecordEntityMutation(ctx context.Context, record *EntityMutationRecord) error {
+	if record == nil {
+		return fmt.Errorf("record cannot be nil")
+	}
+
+	if record.ID == "" {
+		record.ID = uuid.New().String()
+	}
+
+	if record.ServiceID == "" {
+		record.ServiceID = j.serviceID
+	}
+
+	if record.Timestamp.IsZero() {
+		record.Timestamp = time.Now()
+	}
+
+	if record.SyncStatus == "" {
+		record.SyncStatus = SyncStatusPending
+	}
+
+	j.syncMu.Lock()
+	defer j.syncMu.Unlock()
+
+	// Add to main list
+	j.entityMutations = append(j.entityMutations, record)
+
+	// Update indexes
+	entityKey := fmt.Sprintf("%s:%s", record.EntityType, record.EntityID)
+	j.byEntityID[entityKey] = append(j.byEntityID[entityKey], record)
+
+	if record.CorrelationID != "" {
+		j.byCorrelationID[record.CorrelationID] = append(j.byCorrelationID[record.CorrelationID], record)
+	}
+
+	j.bySyncStatus[record.SyncStatus] = append(j.bySyncStatus[record.SyncStatus], record)
+
+	// Also record in base journal for general mutation tracking
+	entry := &MutationEntry{
+		ID:            record.ID,
+		Timestamp:     record.Timestamp,
+		MessageID:     record.CorrelationID,
+		MessageType:   string(record.MutationType),
+		MutationType:  MutationType(record.MutationType),
+		Component:     "entity-sync",
+		Operation:     string(record.MutationType),
+		BeforeState:   record.BeforeState,
+		AfterState:    record.AfterState,
+		CorrelationID: record.CorrelationID,
+		Metadata: map[string]interface{}{
+			"entityType":    record.EntityType,
+			"entityId":      record.EntityID,
+			"entityVersion": record.EntityVersion,
+			"syncStatus":    record.SyncStatus,
+		},
+	}
+
+	return j.InMemoryJournal.Record(ctx, entry)
+}
+
+// GetEntityMutations retrieves mutations for a specific entity
+func (j *InMemorySyncMutationJournal) GetEntityMutations(ctx context.Context, entityType, entityID string) ([]*EntityMutationRecord, error) {
+	j.syncMu.RLock()
+	defer j.syncMu.RUnlock()
+
+	entityKey := fmt.Sprintf("%s:%s", entityType, entityID)
+	mutations, exists := j.byEntityID[entityKey]
+	if !exists {
+		return []*EntityMutationRecord{}, nil
+	}
+
+	// Return copies to prevent external modifications
+	result := make([]*EntityMutationRecord, len(mutations))
+	for i, mutation := range mutations {
+		mutationCopy := *mutation
+		result[i] = &mutationCopy
+	}
+
+	return result, nil
+}
+
+// GetCorrelatedMutations retrieves mutations with the same correlation ID
+func (j *InMemorySyncMutationJournal) GetCorrelatedMutations(ctx context.Context, correlationID string) ([]*EntityMutationRecord, error) {
+	j.syncMu.RLock()
+	defer j.syncMu.RUnlock()
+
+	mutations, exists := j.byCorrelationID[correlationID]
+	if !exists {
+		return []*EntityMutationRecord{}, nil
+	}
+
+	// Return copies
+	result := make([]*EntityMutationRecord, len(mutations))
+	for i, mutation := range mutations {
+		mutationCopy := *mutation
+		result[i] = &mutationCopy
+	}
+
+	return result, nil
+}
+
+// GetUnsyncedMutations retrieves mutations that haven't been synced
+func (j *InMemorySyncMutationJournal) GetUnsyncedMutations(ctx context.Context, limit int) ([]*EntityMutationRecord, error) {
+	j.syncMu.RLock()
+	defer j.syncMu.RUnlock()
+
+	pending := j.bySyncStatus[SyncStatusPending]
+	failed := j.bySyncStatus[SyncStatusFailed]
+
+	// Combine pending and failed mutations
+	unsynced := make([]*EntityMutationRecord, 0, len(pending)+len(failed))
+	unsynced = append(unsynced, pending...)
+	unsynced = append(unsynced, failed...)
+
+	// Apply limit
+	if limit > 0 && len(unsynced) > limit {
+		unsynced = unsynced[:limit]
+	}
+
+	// Return copies
+	result := make([]*EntityMutationRecord, len(unsynced))
+	for i, mutation := range unsynced {
+		mutationCopy := *mutation
+		result[i] = &mutationCopy
+	}
+
+	return result, nil
+}
+
+// MarkAsSynced marks mutations as successfully synced
+func (j *InMemorySyncMutationJournal) MarkAsSynced(ctx context.Context, mutationIDs []string, syncedAt time.Time) error {
+	j.syncMu.Lock()
+	defer j.syncMu.Unlock()
+
+	for _, mutationID := range mutationIDs {
+		if err := j.updateSyncStatus(mutationID, SyncStatusSynced, "", &syncedAt); err != nil {
+			return fmt.Errorf("failed to mark mutation %s as synced: %w", mutationID, err)
+		}
+	}
+
+	return nil
+}
+
+// MarkAsFailed marks mutations as sync failed
+func (j *InMemorySyncMutationJournal) MarkAsFailed(ctx context.Context, mutationIDs []string, syncError string) error {
+	j.syncMu.Lock()
+	defer j.syncMu.Unlock()
+
+	for _, mutationID := range mutationIDs {
+		if err := j.updateSyncStatus(mutationID, SyncStatusFailed, syncError, nil); err != nil {
+			return fmt.Errorf("failed to mark mutation %s as failed: %w", mutationID, err)
+		}
+	}
+
+	return nil
+}
+
+// updateSyncStatus updates the sync status of a mutation (must be called with lock held)
+func (j *InMemorySyncMutationJournal) updateSyncStatus(mutationID string, status SyncStatus, syncError string, syncedAt *time.Time) error {
+	// Find mutation
+	var targetMutation *EntityMutationRecord
+	for _, mutation := range j.entityMutations {
+		if mutation.ID == mutationID {
+			targetMutation = mutation
+			break
+		}
+	}
+
+	if targetMutation == nil {
+		return fmt.Errorf("mutation not found: %s", mutationID)
+	}
+
+	// Remove from old status index
+	j.removeFromSyncStatusIndex(targetMutation)
+
+	// Update status
+	targetMutation.SyncStatus = status
+	targetMutation.SyncError = syncError
+	targetMutation.SyncedAt = syncedAt
+
+	// Add to new status index
+	j.bySyncStatus[status] = append(j.bySyncStatus[status], targetMutation)
+
+	return nil
+}
+
+// removeFromSyncStatusIndex removes a mutation from its current status index
+func (j *InMemorySyncMutationJournal) removeFromSyncStatusIndex(mutation *EntityMutationRecord) {
+	statusMutations := j.bySyncStatus[mutation.SyncStatus]
+	for i, m := range statusMutations {
+		if m.ID == mutation.ID {
+			// Remove from slice
+			j.bySyncStatus[mutation.SyncStatus] = append(statusMutations[:i], statusMutations[i+1:]...)
+			break
+		}
+	}
+}
+
+// QueryMutations retrieves mutations based on query criteria
+func (j *InMemorySyncMutationJournal) QueryMutations(ctx context.Context, query *MutationQuery) ([]*EntityMutationRecord, error) {
+	j.syncMu.RLock()
+	defer j.syncMu.RUnlock()
+
+	var result []*EntityMutationRecord
+
+	// Start with all mutations and filter
+	for _, mutation := range j.entityMutations {
+		if j.matchesQuery(mutation, query) {
+			mutationCopy := *mutation
+			result = append(result, &mutationCopy)
+		}
+	}
+
+	// Apply offset and limit
+	if query.Offset > 0 && query.Offset < len(result) {
+		result = result[query.Offset:]
+	}
+
+	if query.Limit > 0 && len(result) > query.Limit {
+		result = result[:query.Limit]
+	}
+
+	return result, nil
+}
+
+// matchesQuery checks if a mutation matches the query criteria
+func (j *InMemorySyncMutationJournal) matchesQuery(mutation *EntityMutationRecord, query *MutationQuery) bool {
+	if query.EntityType != "" && mutation.EntityType != query.EntityType {
+		return false
+	}
+
+	if query.EntityID != "" && mutation.EntityID != query.EntityID {
+		return false
+	}
+
+	if query.ServiceID != "" && mutation.ServiceID != query.ServiceID {
+		return false
+	}
+
+	if query.CorrelationID != "" && mutation.CorrelationID != query.CorrelationID {
+		return false
+	}
+
+	if query.SyncStatus != "" && mutation.SyncStatus != query.SyncStatus {
+		return false
+	}
+
+	if query.FromTime != nil && mutation.Timestamp.Before(*query.FromTime) {
+		return false
+	}
+
+	if query.ToTime != nil && mutation.Timestamp.After(*query.ToTime) {
+		return false
+	}
+
+	return true
+}
+
+// GetConflicts retrieves mutations that have sync conflicts
+func (j *InMemorySyncMutationJournal) GetConflicts(ctx context.Context) ([]*EntityMutationRecord, error) {
+	j.syncMu.RLock()
+	defer j.syncMu.RUnlock()
+
+	conflicts := j.bySyncStatus[SyncStatusConflict]
+
+	// Return copies
+	result := make([]*EntityMutationRecord, len(conflicts))
+	for i, mutation := range conflicts {
+		mutationCopy := *mutation
+		result[i] = &mutationCopy
+	}
+
+	return result, nil
+}
+
+// ResolveConflict resolves a sync conflict
+func (j *InMemorySyncMutationJournal) ResolveConflict(ctx context.Context, mutationID string, resolution SyncStatus) error {
+	j.syncMu.Lock()
+	defer j.syncMu.Unlock()
+
+	now := time.Now()
+	return j.updateSyncStatus(mutationID, resolution, "", &now)
+}

--- a/internal/reliability/ttl_retry_scheduler.go
+++ b/internal/reliability/ttl_retry_scheduler.go
@@ -1,0 +1,347 @@
+package reliability
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/glimte/mmate-go/contracts"
+	"github.com/glimte/mmate-go/internal/rabbitmq"
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+// TTLRetryScheduler implements retry scheduling using RabbitMQ TTL and DLX
+type TTLRetryScheduler struct {
+	channelPool      *rabbitmq.ChannelPool
+	topologyManager  *rabbitmq.TopologyManager
+	logger          *slog.Logger
+	retryExchange   string
+	delayExchange   string
+	mu              sync.RWMutex
+	delayQueues     map[string]bool // Track created delay queues
+}
+
+// RetryMessage represents a message scheduled for retry
+type RetryMessage struct {
+	MessageID       string                 `json:"messageId"`
+	MessageType     string                 `json:"messageType"`
+	CorrelationID   string                 `json:"correlationId"`
+	OriginalPayload json.RawMessage        `json:"originalPayload"`
+	OriginalQueue   string                 `json:"originalQueue"`
+	AttemptNumber   int                    `json:"attemptNumber"`
+	MaxAttempts     int                    `json:"maxAttempts"`
+	RetryPolicy     string                 `json:"retryPolicy"`
+	ScheduledAt     time.Time              `json:"scheduledAt"`
+	RetryAt         time.Time              `json:"retryAt"`
+	LastError       string                 `json:"lastError,omitempty"`
+	Metadata        map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// TTLRetrySchedulerOptions configures the TTL retry scheduler
+type TTLRetrySchedulerOptions struct {
+	RetryExchange string
+	DelayExchange string
+	Logger        *slog.Logger
+}
+
+// NewTTLRetryScheduler creates a new TTL-based retry scheduler
+func NewTTLRetryScheduler(pool *rabbitmq.ChannelPool, opts *TTLRetrySchedulerOptions) *TTLRetryScheduler {
+	if opts == nil {
+		opts = &TTLRetrySchedulerOptions{}
+	}
+
+	if opts.RetryExchange == "" {
+		opts.RetryExchange = "mmate.retry"
+	}
+	if opts.DelayExchange == "" {
+		opts.DelayExchange = "mmate.retry.delay"
+	}
+	if opts.Logger == nil {
+		opts.Logger = slog.Default()
+	}
+
+	scheduler := &TTLRetryScheduler{
+		channelPool:     pool,
+		topologyManager: rabbitmq.NewTopologyManager(pool),
+		logger:          opts.Logger,
+		retryExchange:   opts.RetryExchange,
+		delayExchange:   opts.DelayExchange,
+		delayQueues:     make(map[string]bool),
+	}
+
+	return scheduler
+}
+
+// Initialize sets up the required RabbitMQ topology for TTL-based retries
+func (s *TTLRetryScheduler) Initialize(ctx context.Context) error {
+	s.logger.Info("Initializing TTL retry scheduler topology")
+
+	// Create retry exchanges
+	exchanges := []rabbitmq.ExchangeDeclaration{
+		{
+			Name:    s.retryExchange,
+			Type:    "direct",
+			Durable: true,
+		},
+		{
+			Name:    s.delayExchange,
+			Type:    "direct",
+			Durable: true,
+		},
+	}
+
+	for _, exchange := range exchanges {
+		if err := s.topologyManager.DeclareExchange(ctx, exchange); err != nil {
+			return fmt.Errorf("failed to declare exchange %s: %w", exchange.Name, err)
+		}
+	}
+
+	s.logger.Info("TTL retry scheduler topology initialized")
+	return nil
+}
+
+// ScheduleRetry schedules a message for retry using TTL and DLX
+func (s *TTLRetryScheduler) ScheduleRetry(ctx context.Context, msg contracts.Message, originalQueue string, attempt int, policy RetryPolicy, delay time.Duration, lastErr error) error {
+	// Check if we should retry
+	shouldRetry, _ := policy.ShouldRetry(attempt, lastErr)
+	if !shouldRetry {
+		return fmt.Errorf("retry policy indicates no more retries for attempt %d", attempt)
+	}
+
+	// Serialize original message
+	payload, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("failed to serialize message for retry: %w", err)
+	}
+
+	retryMessage := &RetryMessage{
+		MessageID:       msg.GetID(),
+		MessageType:     msg.GetType(),
+		CorrelationID:   msg.GetCorrelationID(),
+		OriginalPayload: json.RawMessage(payload),
+		OriginalQueue:   originalQueue,
+		AttemptNumber:   attempt + 1,
+		MaxAttempts:     policy.MaxRetries(),
+		RetryPolicy:     fmt.Sprintf("%T", policy),
+		ScheduledAt:     time.Now(),
+		RetryAt:         time.Now().Add(delay),
+	}
+
+	if lastErr != nil {
+		retryMessage.LastError = lastErr.Error()
+	}
+
+	// Create delay queue for this specific delay if it doesn't exist
+	delayQueueName := s.getDelayQueueName(delay)
+	if err := s.ensureDelayQueue(ctx, delayQueueName, delay, originalQueue); err != nil {
+		return fmt.Errorf("failed to ensure delay queue: %w", err)
+	}
+
+	// Publish to delay queue
+	if err := s.publishToDelayQueue(ctx, delayQueueName, retryMessage); err != nil {
+		return fmt.Errorf("failed to publish to delay queue: %w", err)
+	}
+
+	s.logger.Info("Scheduled message for retry",
+		"messageId", msg.GetID(),
+		"attempt", retryMessage.AttemptNumber,
+		"delay", delay,
+		"retryAt", retryMessage.RetryAt)
+
+	return nil
+}
+
+// getDelayQueueName generates a queue name for a specific delay
+func (s *TTLRetryScheduler) getDelayQueueName(delay time.Duration) string {
+	// Round to nearest second to avoid too many queues
+	seconds := int(delay.Seconds())
+	return fmt.Sprintf("mmate.retry.delay.%ds", seconds)
+}
+
+// ensureDelayQueue creates a delay queue if it doesn't exist
+func (s *TTLRetryScheduler) ensureDelayQueue(ctx context.Context, queueName string, delay time.Duration, targetQueue string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Check if already created
+	if s.delayQueues[queueName] {
+		return nil
+	}
+
+	// Create delay queue with TTL and DLX pointing to target queue
+	queue := rabbitmq.QueueDeclaration{
+		Name:    queueName,
+		Durable: true,
+		Arguments: amqp.Table{
+			"x-message-ttl":            int(delay.Milliseconds()),
+			"x-dead-letter-exchange":   s.retryExchange,
+			"x-dead-letter-routing-key": targetQueue,
+			"x-expires":                int(delay.Milliseconds()) + 300000, // Queue expires 5 min after TTL
+		},
+	}
+
+	if _, err := s.topologyManager.DeclareQueue(ctx, queue); err != nil {
+		return fmt.Errorf("failed to declare delay queue %s: %w", queueName, err)
+	}
+
+	// Bind delay queue to delay exchange
+	binding := rabbitmq.Binding{
+		Queue:      queueName,
+		Exchange:   s.delayExchange,
+		RoutingKey: queueName,
+	}
+
+	if err := s.topologyManager.BindQueue(ctx, binding); err != nil {
+		return fmt.Errorf("failed to bind delay queue %s: %w", queueName, err)
+	}
+
+	s.delayQueues[queueName] = true
+	s.logger.Debug("Created delay queue",
+		"queue", queueName,
+		"delay", delay,
+		"targetQueue", targetQueue)
+
+	return nil
+}
+
+// publishToDelayQueue publishes a retry message to the delay queue
+func (s *TTLRetryScheduler) publishToDelayQueue(ctx context.Context, queueName string, retryMsg *RetryMessage) error {
+	return s.channelPool.Execute(ctx, func(ch *amqp.Channel) error {
+		body, err := json.Marshal(retryMsg)
+		if err != nil {
+			return fmt.Errorf("failed to marshal retry message: %w", err)
+		}
+
+		return ch.PublishWithContext(
+			ctx,
+			s.delayExchange, // exchange
+			queueName,       // routing key
+			false,           // mandatory
+			false,           // immediate
+			amqp.Publishing{
+				ContentType:  "application/json",
+				Body:         body,
+				DeliveryMode: amqp.Persistent,
+				MessageId:    retryMsg.MessageID,
+				CorrelationId: retryMsg.CorrelationID,
+				Timestamp:    retryMsg.ScheduledAt,
+				Headers: amqp.Table{
+					"x-retry-attempt":      retryMsg.AttemptNumber,
+					"x-retry-max-attempts": retryMsg.MaxAttempts,
+					"x-retry-original-queue": retryMsg.OriginalQueue,
+					"x-retry-scheduled-at": retryMsg.ScheduledAt.Unix(),
+					"x-retry-at":          retryMsg.RetryAt.Unix(),
+				},
+			},
+		)
+	})
+}
+
+// SetupRetryConsumer sets up a consumer for retry messages on the target queue
+func (s *TTLRetryScheduler) SetupRetryConsumer(ctx context.Context, targetQueue string, handler func(ctx context.Context, retryMsg *RetryMessage) error) error {
+	// Ensure target queue is bound to retry exchange
+	binding := rabbitmq.Binding{
+		Queue:      targetQueue,
+		Exchange:   s.retryExchange,
+		RoutingKey: targetQueue,
+	}
+
+	if err := s.topologyManager.BindQueue(ctx, binding); err != nil {
+		return fmt.Errorf("failed to bind target queue to retry exchange: %w", err)
+	}
+
+	s.logger.Info("Set up retry consumer", "queue", targetQueue)
+	return nil
+}
+
+// TTLRetryPolicyAdapter adapts existing retry policies to work with TTL scheduler
+type TTLRetryPolicyAdapter struct {
+	policy    RetryPolicy
+	scheduler *TTLRetryScheduler
+	queue     string
+}
+
+// NewTTLRetryPolicyAdapter creates an adapter for existing retry policies
+func NewTTLRetryPolicyAdapter(policy RetryPolicy, scheduler *TTLRetryScheduler, queue string) *TTLRetryPolicyAdapter {
+	return &TTLRetryPolicyAdapter{
+		policy:    policy,
+		scheduler: scheduler,
+		queue:     queue,
+	}
+}
+
+// ExecuteWithRetry executes a function with TTL-based retry
+func (a *TTLRetryPolicyAdapter) ExecuteWithRetry(ctx context.Context, msg contracts.Message, fn func() error) error {
+	var lastErr error
+	
+	for attempt := 0; ; attempt++ {
+		// Check context
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		// Execute function
+		err := fn()
+		if err == nil {
+			return nil
+		}
+
+		lastErr = err
+
+		// Check if we should retry
+		shouldRetry, delay := a.policy.ShouldRetry(attempt, err)
+		if !shouldRetry {
+			return lastErr
+		}
+
+		// Use TTL-based retry instead of time.Sleep
+		if err := a.scheduler.ScheduleRetry(ctx, msg, a.queue, attempt, a.policy, delay, lastErr); err != nil {
+			a.scheduler.logger.Error("Failed to schedule TTL retry", "error", err)
+			// Fall back to in-memory retry
+			select {
+			case <-time.After(delay):
+				continue
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+
+		// Message scheduled for retry, return special error to indicate this
+		return &ScheduledRetryError{
+			OriginalError: lastErr,
+			AttemptNumber: attempt + 1,
+			RetryAt:       time.Now().Add(delay),
+		}
+	}
+}
+
+// ScheduledRetryError indicates a message was scheduled for retry
+type ScheduledRetryError struct {
+	OriginalError error
+	AttemptNumber int
+	RetryAt       time.Time
+}
+
+func (e *ScheduledRetryError) Error() string {
+	return fmt.Sprintf("message scheduled for retry (attempt %d at %v): %v", 
+		e.AttemptNumber, e.RetryAt, e.OriginalError)
+}
+
+func (e *ScheduledRetryError) Unwrap() error {
+	return e.OriginalError
+}
+
+func (e *ScheduledRetryError) IsScheduledRetry() bool {
+	return true
+}
+
+// Close cleans up resources
+func (s *TTLRetryScheduler) Close() error {
+	// Channel pool will be closed by the transport
+	return nil
+}

--- a/messaging/acknowledgment_tracker.go
+++ b/messaging/acknowledgment_tracker.go
@@ -1,0 +1,364 @@
+package messaging
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/glimte/mmate-go/contracts"
+	"github.com/google/uuid"
+)
+
+// ProcessingAcknowledment represents an application-level processing acknowledgment
+type ProcessingAcknowledment struct {
+	CorrelationID   string                 `json:"correlationId"`
+	MessageID       string                 `json:"messageId"`
+	MessageType     string                 `json:"messageType"`
+	Success         bool                   `json:"success"`
+	ErrorMessage    string                 `json:"errorMessage,omitempty"`
+	ProcessingTime  time.Duration          `json:"processingTime"`
+	ProcessedAt     time.Time              `json:"processedAt"`
+	ProcessorID     string                 `json:"processorId"`
+	Metadata        map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// AckResponse represents a pending acknowledgment response
+type AckResponse struct {
+	CorrelationID string
+	ch            chan *ProcessingAcknowledment
+	timeout       time.Duration
+	createdAt     time.Time
+	mu            sync.Mutex
+	completed     bool
+}
+
+// NewAckResponse creates a new acknowledgment response
+func NewAckResponse(correlationID string, timeout time.Duration) *AckResponse {
+	return &AckResponse{
+		CorrelationID: correlationID,
+		ch:            make(chan *ProcessingAcknowledment, 1),
+		timeout:       timeout,
+		createdAt:     time.Now(),
+	}
+}
+
+// WaitForAcknowledgment waits for the processing acknowledgment with timeout
+func (r *AckResponse) WaitForAcknowledgment(ctx context.Context) (*ProcessingAcknowledment, error) {
+	select {
+	case ack := <-r.ch:
+		return ack, nil
+	case <-time.After(r.timeout):
+		r.mu.Lock()
+		r.completed = true
+		r.mu.Unlock()
+		return nil, fmt.Errorf("acknowledgment timeout after %v for correlation %s", r.timeout, r.CorrelationID)
+	case <-ctx.Done():
+		r.mu.Lock()
+		r.completed = true
+		r.mu.Unlock()
+		return nil, ctx.Err()
+	}
+}
+
+// IsCompleted returns true if the acknowledgment was received or timed out
+func (r *AckResponse) IsCompleted() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.completed
+}
+
+// complete delivers the acknowledgment
+func (r *AckResponse) complete(ack *ProcessingAcknowledment) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	
+	if r.completed {
+		return false
+	}
+	
+	r.completed = true
+	select {
+	case r.ch <- ack:
+		return true
+	default:
+		return false
+	}
+}
+
+// AcknowledgmentTracker manages application-level acknowledgments
+type AcknowledgmentTracker struct {
+	publisher        Publisher
+	ackQueue         string
+	pendingAcks      map[string]*AckResponse
+	defaultTimeout   time.Duration
+	cleanupInterval  time.Duration
+	logger          *slog.Logger
+	mu              sync.RWMutex
+	ctx             context.Context
+	cancel          context.CancelFunc
+	wg              sync.WaitGroup
+}
+
+// AcknowledgmentTrackerOptions configures the acknowledgment tracker
+type AcknowledgmentTrackerOptions struct {
+	AckQueue        string
+	DefaultTimeout  time.Duration
+	CleanupInterval time.Duration
+	Logger          *slog.Logger
+}
+
+// NewAcknowledgmentTracker creates a new acknowledgment tracker
+func NewAcknowledgmentTracker(publisher Publisher, opts *AcknowledgmentTrackerOptions) *AcknowledgmentTracker {
+	if opts == nil {
+		opts = &AcknowledgmentTrackerOptions{}
+	}
+
+	if opts.AckQueue == "" {
+		opts.AckQueue = "mmate.acknowledgments"
+	}
+	if opts.DefaultTimeout == 0 {
+		opts.DefaultTimeout = 30 * time.Second
+	}
+	if opts.CleanupInterval == 0 {
+		opts.CleanupInterval = 5 * time.Minute
+	}
+	if opts.Logger == nil {
+		opts.Logger = slog.Default()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	tracker := &AcknowledgmentTracker{
+		publisher:       publisher,
+		ackQueue:        opts.AckQueue,
+		pendingAcks:     make(map[string]*AckResponse),
+		defaultTimeout:  opts.DefaultTimeout,
+		cleanupInterval: opts.CleanupInterval,
+		logger:          opts.Logger,
+		ctx:             ctx,
+		cancel:          cancel,
+	}
+
+	// Start cleanup routine
+	tracker.wg.Add(1)
+	go tracker.cleanupRoutine()
+
+	return tracker
+}
+
+// SendWithAck sends a message and returns an acknowledgment response
+func (t *AcknowledgmentTracker) SendWithAck(ctx context.Context, msg contracts.Message, options ...PublishOption) (*AckResponse, error) {
+	// Generate correlation ID if not present
+	correlationID := msg.GetCorrelationID()
+	if correlationID == "" {
+		correlationID = uuid.New().String()
+		msg.SetCorrelationID(correlationID)
+	}
+
+	// Create acknowledgment response
+	ackResponse := NewAckResponse(correlationID, t.defaultTimeout)
+
+	// Register pending acknowledgment
+	t.mu.Lock()
+	t.pendingAcks[correlationID] = ackResponse
+	t.mu.Unlock()
+
+	t.logger.Debug("Registered pending acknowledgment",
+		"correlationId", correlationID,
+		"messageId", msg.GetID())
+
+	// Add reply-to header for acknowledgment
+	options = append(options, WithReplyTo(t.ackQueue))
+
+	// Publish message
+	err := t.publisher.Publish(ctx, msg, options...)
+	if err != nil {
+		// Remove pending ack on publish failure
+		t.mu.Lock()
+		delete(t.pendingAcks, correlationID)
+		t.mu.Unlock()
+		return nil, fmt.Errorf("failed to publish message with ack: %w", err)
+	}
+
+	t.logger.Info("Message sent with acknowledgment tracking",
+		"messageId", msg.GetID(),
+		"correlationId", correlationID)
+
+	return ackResponse, nil
+}
+
+// HandleAcknowledgment processes an incoming acknowledgment
+func (t *AcknowledgmentTracker) HandleAcknowledgment(ctx context.Context, ackMsg contracts.Message) error {
+	// Deserialize acknowledgment
+	var ack ProcessingAcknowledment
+	if err := json.Unmarshal([]byte(ackMsg.GetType()), &ack); err != nil {
+		// Try to extract from message content if type parsing fails
+		if ackMessage, ok := ackMsg.(*AcknowledgmentMessage); ok {
+			ack = ProcessingAcknowledment{
+				CorrelationID:  ackMessage.CorrelationID,
+				MessageID:      ackMessage.MessageID,
+				MessageType:    ackMessage.MessageType,
+				Success:        ackMessage.Success,
+				ErrorMessage:   ackMessage.ErrorMessage,
+				ProcessingTime: ackMessage.ProcessingTime,
+				ProcessedAt:    ackMessage.ProcessedAt,
+				ProcessorID:    ackMessage.ProcessorID,
+				Metadata:       ackMessage.Metadata,
+			}
+		} else {
+			return fmt.Errorf("failed to deserialize acknowledgment: %w", err)
+		}
+	}
+
+	correlationID := ack.CorrelationID
+	if correlationID == "" {
+		correlationID = ackMsg.GetCorrelationID()
+	}
+
+	if correlationID == "" {
+		return fmt.Errorf("acknowledgment missing correlation ID")
+	}
+
+	// Find pending acknowledgment
+	t.mu.Lock()
+	ackResponse, exists := t.pendingAcks[correlationID]
+	if exists {
+		delete(t.pendingAcks, correlationID)
+	}
+	t.mu.Unlock()
+
+	if !exists {
+		t.logger.Warn("Received acknowledgment for unknown correlation ID",
+			"correlationId", correlationID)
+		return nil
+	}
+
+	// Complete the acknowledgment
+	if ackResponse.complete(&ack) {
+		t.logger.Info("Acknowledgment received",
+			"correlationId", correlationID,
+			"success", ack.Success,
+			"processingTime", ack.ProcessingTime)
+	} else {
+		t.logger.Warn("Failed to deliver acknowledgment (already completed)",
+			"correlationId", correlationID)
+	}
+
+	return nil
+}
+
+// GetPendingAcksCount returns the number of pending acknowledgments
+func (t *AcknowledgmentTracker) GetPendingAcksCount() int {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return len(t.pendingAcks)
+}
+
+// cleanupRoutine removes expired pending acknowledgments
+func (t *AcknowledgmentTracker) cleanupRoutine() {
+	defer t.wg.Done()
+	
+	ticker := time.NewTicker(t.cleanupInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			t.cleanup()
+		case <-t.ctx.Done():
+			return
+		}
+	}
+}
+
+// cleanup removes expired acknowledgments
+func (t *AcknowledgmentTracker) cleanup() {
+	now := time.Now()
+	var expired []string
+
+	t.mu.RLock()
+	for correlationID, ackResponse := range t.pendingAcks {
+		if now.Sub(ackResponse.createdAt) > ackResponse.timeout*2 {
+			expired = append(expired, correlationID)
+		}
+	}
+	t.mu.RUnlock()
+
+	if len(expired) > 0 {
+		t.mu.Lock()
+		for _, correlationID := range expired {
+			delete(t.pendingAcks, correlationID)
+		}
+		t.mu.Unlock()
+
+		t.logger.Info("Cleaned up expired acknowledgments", "count", len(expired))
+	}
+}
+
+// Close shuts down the acknowledgment tracker
+func (t *AcknowledgmentTracker) Close() error {
+	t.cancel()
+	t.wg.Wait()
+
+	// Complete any remaining pending acknowledgments with timeout error
+	t.mu.Lock()
+	for correlationID, ackResponse := range t.pendingAcks {
+		ackResponse.complete(&ProcessingAcknowledment{
+			CorrelationID: correlationID,
+			Success:       false,
+			ErrorMessage:  "acknowledgment tracker closed",
+			ProcessedAt:   time.Now(),
+		})
+	}
+	t.pendingAcks = make(map[string]*AckResponse)
+	t.mu.Unlock()
+
+	return nil
+}
+
+// AcknowledgmentMessage represents an acknowledgment message
+type AcknowledgmentMessage struct {
+	contracts.BaseMessage
+	CorrelationID   string                 `json:"correlationId"`
+	MessageID       string                 `json:"messageId"`
+	MessageType     string                 `json:"messageType"`
+	Success         bool                   `json:"success"`
+	ErrorMessage    string                 `json:"errorMessage,omitempty"`
+	ProcessingTime  time.Duration          `json:"processingTime"`
+	ProcessedAt     time.Time              `json:"processedAt"`
+	ProcessorID     string                 `json:"processorId"`
+	Metadata        map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// NewAcknowledgmentMessage creates a new acknowledgment message
+func NewAcknowledgmentMessage(correlationID, messageID, messageType string, success bool) *AcknowledgmentMessage {
+	return &AcknowledgmentMessage{
+		BaseMessage: contracts.BaseMessage{
+			ID:            uuid.New().String(),
+			Type:          "ProcessingAcknowledgment",
+			Timestamp:     time.Now(),
+			CorrelationID: correlationID,
+		},
+		CorrelationID: correlationID,
+		MessageID:     messageID,
+		MessageType:   messageType,
+		Success:       success,
+		ProcessedAt:   time.Now(),
+	}
+}
+
+// IsSuccess implements the Reply interface
+func (a *AcknowledgmentMessage) IsSuccess() bool {
+	return a.Success
+}
+
+// GetError implements the Reply interface
+func (a *AcknowledgmentMessage) GetError() error {
+	if a.ErrorMessage == "" {
+		return nil
+	}
+	return fmt.Errorf(a.ErrorMessage)
+}

--- a/messaging/processing_ack_handler.go
+++ b/messaging/processing_ack_handler.go
@@ -1,0 +1,188 @@
+package messaging
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/glimte/mmate-go/contracts"
+	"github.com/glimte/mmate-go/interceptors"
+)
+
+// ProcessingAckHandler wraps a message handler to send processing acknowledgments
+type ProcessingAckHandler struct {
+	handler     interceptors.MessageHandler
+	publisher   *MessagePublisher
+	logger      *slog.Logger
+	processorID string
+}
+
+// ProcessingAckHandlerOptions configures the processing acknowledgment handler
+type ProcessingAckHandlerOptions struct {
+	Logger      *slog.Logger
+	ProcessorID string
+}
+
+// NewProcessingAckHandler creates a new processing acknowledgment handler
+func NewProcessingAckHandler(handler interceptors.MessageHandler, publisher *MessagePublisher, opts *ProcessingAckHandlerOptions) *ProcessingAckHandler {
+	if opts == nil {
+		opts = &ProcessingAckHandlerOptions{}
+	}
+
+	if opts.Logger == nil {
+		opts.Logger = slog.Default()
+	}
+
+	if opts.ProcessorID == "" {
+		hostname, _ := os.Hostname()
+		opts.ProcessorID = fmt.Sprintf("%s-%d", hostname, os.Getpid())
+	}
+
+	return &ProcessingAckHandler{
+		handler:     handler,
+		publisher:   publisher,
+		logger:      opts.Logger,
+		processorID: opts.ProcessorID,
+	}
+}
+
+// Handle processes the message and sends acknowledgment
+func (h *ProcessingAckHandler) Handle(ctx context.Context, msg contracts.Message) error {
+	startTime := time.Now()
+	
+	// Check if message expects acknowledgment
+	replyTo := h.getReplyTo(ctx, msg)
+	if replyTo == "" {
+		// No acknowledgment expected, process normally
+		return h.handler.Handle(ctx, msg)
+	}
+
+	correlationID := msg.GetCorrelationID()
+	if correlationID == "" {
+		// No correlation ID, process normally
+		return h.handler.Handle(ctx, msg)
+	}
+
+	h.logger.Debug("Processing message with acknowledgment",
+		"messageId", msg.GetID(),
+		"correlationId", correlationID,
+		"replyTo", replyTo)
+
+	// Process the message
+	err := h.handler.Handle(ctx, msg)
+	processingTime := time.Since(startTime)
+
+	// Create acknowledgment
+	ack := NewAcknowledgmentMessage(correlationID, msg.GetID(), msg.GetType(), err == nil)
+	ack.ProcessingTime = processingTime
+	ack.ProcessorID = h.processorID
+
+	if err != nil {
+		ack.ErrorMessage = err.Error()
+	}
+
+	// Add processing metadata
+	ack.Metadata = map[string]interface{}{
+		"processingStartedAt": startTime,
+		"processingEndedAt":   time.Now(),
+		"processorVersion":    "mmate-go/1.0",
+	}
+
+	// Send acknowledgment
+	ackErr := h.publisher.PublishReply(ctx, ack, replyTo)
+	if ackErr != nil {
+		h.logger.Error("Failed to send processing acknowledgment",
+			"messageId", msg.GetID(),
+			"correlationId", correlationID,
+			"replyTo", replyTo,
+			"error", ackErr)
+	} else {
+		h.logger.Info("Sent processing acknowledgment",
+			"messageId", msg.GetID(),
+			"correlationId", correlationID,
+			"success", err == nil,
+			"processingTime", processingTime)
+	}
+
+	return err
+}
+
+// getReplyTo extracts the reply-to queue from context or message headers
+func (h *ProcessingAckHandler) getReplyTo(ctx context.Context, msg contracts.Message) string {
+	// Try to get from interceptor context first
+	if intercCtx, ok := interceptors.GetInterceptorContext(ctx); ok {
+		if replyTo, exists := intercCtx.Get("reply-to"); exists {
+			if replyToStr, ok := replyTo.(string); ok {
+				return replyToStr
+			}
+		}
+	}
+
+	// Try to get from message if it implements ReplyTo interface
+	if replyMsg, ok := msg.(interface{ GetReplyTo() string }); ok {
+		return replyMsg.GetReplyTo()
+	}
+
+	return ""
+}
+
+// AutoAckMessageHandlerFunc is a function adapter for processing acknowledgment handlers
+type AutoAckMessageHandlerFunc func(ctx context.Context, msg contracts.Message) error
+
+// Handle implements MessageHandler
+func (f AutoAckMessageHandlerFunc) Handle(ctx context.Context, msg contracts.Message) error {
+	return f(ctx, msg)
+}
+
+// WithProcessingAck wraps a handler function to automatically send processing acknowledgments
+func WithProcessingAck(publisher *MessagePublisher, handlerFunc AutoAckMessageHandlerFunc, opts *ProcessingAckHandlerOptions) interceptors.MessageHandler {
+	return NewProcessingAckHandler(handlerFunc, publisher, opts)
+}
+
+// ProcessingAckInterceptor automatically adds processing acknowledgment to handlers
+type ProcessingAckInterceptor struct {
+	publisher *MessagePublisher
+	logger    *slog.Logger
+	enabled   bool
+}
+
+// NewProcessingAckInterceptor creates a new processing acknowledgment interceptor
+func NewProcessingAckInterceptor(publisher *MessagePublisher) *ProcessingAckInterceptor {
+	return &ProcessingAckInterceptor{
+		publisher: publisher,
+		logger:    slog.Default(),
+		enabled:   true,
+	}
+}
+
+// Intercept implements the Interceptor interface
+func (i *ProcessingAckInterceptor) Intercept(ctx context.Context, msg contracts.Message, next interceptors.MessageHandler) error {
+	if !i.enabled {
+		return next.Handle(ctx, msg)
+	}
+
+	// Wrap the next handler with processing acknowledgment
+	ackHandler := NewProcessingAckHandler(next, i.publisher, &ProcessingAckHandlerOptions{
+		Logger: i.logger,
+	})
+
+	return ackHandler.Handle(ctx, msg)
+}
+
+// Name returns the interceptor name
+func (i *ProcessingAckInterceptor) Name() string {
+	return "ProcessingAckInterceptor"
+}
+
+// SetEnabled enables or disables the interceptor
+func (i *ProcessingAckInterceptor) SetEnabled(enabled bool) {
+	i.enabled = enabled
+}
+
+// WithLogger sets the logger for the interceptor
+func (i *ProcessingAckInterceptor) WithLogger(logger *slog.Logger) *ProcessingAckInterceptor {
+	i.logger = logger
+	return i
+}


### PR DESCRIPTION


- Implement persistent retry scheduling using RabbitMQ Dead Letter Exchange (DLX)
- Replace time.Sleep() with TTL-based approach that survives service restarts
- Add TTLRetryScheduler with topology management and exponential backoff
- Integrate TTLRetryInterceptor into pipeline for seamless retry handling

- Add end-to-end message processing visibility with correlation ID management
- Implement AcknowledgmentTracker for request/response matching with timeouts
- Add ProcessingAckHandler for automatic acknowledgment generation
- Support SendWithAck() pattern for critical message processing confirmation

- Extend mutation journal with entity-level synchronization capabilities
- Add EntityMutationRecord with before/after state tracking and sync status
- Support entity conflict detection and resolution workflows
- Enable distributed synchronization with correlation-based mutation querying

- Update client API with enterprise methods (TTLRetryScheduler, AcknowledgmentTracker, SyncMutationJournal)
